### PR TITLE
Fixed Travis badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BME680
 
-[![Build Status](https://travis-ci.com/pimoroni/bme680-python.svg?branch=master)](https://travis-ci.com/pimoroni/bme680-python)
+[![Build Status](https://travis-ci.org/pimoroni/bme680-python.svg?branch=master)](https://travis-ci.org/pimoroni/bme680-python)
 [![Coverage Status](https://coveralls.io/repos/github/pimoroni/bme680-python/badge.svg?branch=master)](https://coveralls.io/github/pimoroni/bme680-python?branch=master)
 [![PyPi Package](https://img.shields.io/pypi/v/bme680.svg)](https://pypi.python.org/pypi/bme680)
 [![Python Versions](https://img.shields.io/pypi/pyversions/bme680.svg)](https://pypi.python.org/pypi/bme680)

--- a/library/README.rst
+++ b/library/README.rst
@@ -70,8 +70,8 @@ Documentation & Support
 -  Guides and tutorials - https://learn.pimoroni.com/bme680
 -  Get help - http://forums.pimoroni.com/c/support
 
-.. |Build Status| image:: https://travis-ci.com/pimoroni/bme680-python.svg?branch=master
-   :target: https://travis-ci.com/pimoroni/bme680-python
+.. |Build Status| image:: https://travis-ci.org/pimoroni/bme680-python.svg?branch=master
+   :target: https://travis-ci.org/pimoroni/bme680-python
 .. |Coverage Status| image:: https://coveralls.io/repos/github/pimoroni/bme680-python/badge.svg?branch=master
    :target: https://coveralls.io/github/pimoroni/bme680-python?branch=master
 .. |PyPi Package| image:: https://img.shields.io/pypi/v/bme680.svg


### PR DESCRIPTION
Quick fix to reflect that CI is still running on Travis.org. Should fix the status badges.