### PR TITLE
Add dependency: smbus2

### DIFF
--- a/library/setup.py
+++ b/library/setup.py
@@ -50,5 +50,5 @@ setup(
     classifiers=classifiers,
     packages=['bme680'],
     py_modules=[],
-    install_requires=[]
+    install_requires=['smbus2']
 )

--- a/library/setup.py
+++ b/library/setup.py
@@ -50,5 +50,5 @@ setup(
     classifiers=classifiers,
     packages=['bme680'],
     py_modules=[],
-    install_requires=['smbus2']
+    install_requires=['smbus']  # preferably: install `python3-smbus` instead of relying on this
 )


### PR DESCRIPTION
Fixes:

```python
>>> import bme680                                                                                                                                                                                          
>>> sensor = bme680.BME680(bme680.I2C_ADDR_PRIMARY)                                                                                                                                                        
Traceback (most recent call last):                                                                                                                                                                         
  File "<stdin>", line 1, in <module>                                                                                                                                                                      
  File "/usr/local/lib/python3.7/dist-packages/bme680/__init__.py", line 22, in __init__                                                                                                                   
    import smbus                                                                                                                                                                                           
ModuleNotFoundError: No module named 'smbus'                                                                                                                                                               
```