### PR TITLE
Catch IOError, raise as RuntimeError in init()

### DIFF
--- a/examples/compensated-temperature.py
+++ b/examples/compensated-temperature.py
@@ -15,7 +15,7 @@ Press Ctrl+C to exit!
 
 try:
     sensor = bme680.BME680(bme680.I2C_ADDR_PRIMARY)
-except IOError:
+except (RuntimeError, IOError):
     sensor = bme680.BME680(bme680.I2C_ADDR_SECONDARY)
 
 # These oversampling settings can be tweaked to

--- a/examples/indoor-air-quality.py
+++ b/examples/indoor-air-quality.py
@@ -15,7 +15,7 @@ Press Ctrl+C to exit!
 
 try:
     sensor = bme680.BME680(bme680.I2C_ADDR_PRIMARY)
-except IOError:
+except (RuntimeError, IOError):
     sensor = bme680.BME680(bme680.I2C_ADDR_SECONDARY)
 
 # These oversampling settings can be tweaked to

--- a/examples/read-all.py
+++ b/examples/read-all.py
@@ -11,7 +11,7 @@ Press Ctrl+C to exit!
 
 try:
     sensor = bme680.BME680(bme680.I2C_ADDR_PRIMARY)
-except IOError:
+except (RuntimeError, IOError):
     sensor = bme680.BME680(bme680.I2C_ADDR_SECONDARY)
 
 # These calibration data can safely be commented

--- a/examples/temperature-offset.py
+++ b/examples/temperature-offset.py
@@ -10,7 +10,7 @@ Press Ctrl+C to exit!
 
 try:
     sensor = bme680.BME680(bme680.I2C_ADDR_PRIMARY)
-except IOError:
+except (RuntimeError, IOError):
     sensor = bme680.BME680(bme680.I2C_ADDR_SECONDARY)
 
 # These oversampling settings can be tweaked to

--- a/examples/temperature-pressure-humidity.py
+++ b/examples/temperature-pressure-humidity.py
@@ -13,7 +13,7 @@ Press Ctrl+C to exit
 
 try:
     sensor = bme680.BME680(bme680.I2C_ADDR_PRIMARY)
-except IOError:
+except (RuntimeError, IOError):
     sensor = bme680.BME680(bme680.I2C_ADDR_SECONDARY)
 
 # These oversampling settings can be tweaked to

--- a/library/bme680/__init__.py
+++ b/library/bme680/__init__.py
@@ -42,9 +42,12 @@ class BME680(BME680Data):
             import smbus
             self._i2c = smbus.SMBus(1)
 
-        self.chip_id = self._get_regs(constants.CHIP_ID_ADDR, 1)
-        if self.chip_id != constants.CHIP_ID:
-            raise RuntimeError('BME680 Not Found. Invalid CHIP ID: 0x{0:02x}'.format(self.chip_id))
+        try:
+            self.chip_id = self._get_regs(constants.CHIP_ID_ADDR, 1)
+            if self.chip_id != constants.CHIP_ID:
+                raise RuntimeError('BME680 Not Found. Invalid CHIP ID: 0x{0:02x}'.format(self.chip_id))
+        except IOError:
+            raise RuntimeError("Unable to identify BME680 at 0x{:02x} (IOError)".format(self.i2c_addr))
 
         self.soft_reset()
         self.set_power_mode(constants.SLEEP_MODE)


### PR DESCRIPTION
When checking the chip ID in `init()` (to confirm whether the device is a BME680 or not), errors of type `IOError` are not caught, unlike the [pimoroni/bme280-python](https://github.com/pimoroni/bme280-python) library, where a `try/except` block is used to [catch an `IOError`](https://github.com/pimoroni/bme280-python/blob/97c80ced20b02caa129e98c8801b31f1468ee4b0/library/bme280/__init__.py#L229) and re-raise as `RuntimeError` instead.

This arises, for example, when trying to initialise the device when it doesn't exist at the address. It's not show-stopper, but I thought it might be preferable to be consistent across the two libraries, so this PR adopts the convention used in bme280-python and raises a `RuntimeError` in this situation.

Tangentially relevant to issues #19, #23, #10