### PR TITLE
Add constants for gas heat enable/disable

### DIFF
--- a/library/bme680/constants.py
+++ b/library/bme680/constants.py
@@ -121,6 +121,10 @@ HUM_REG_SHIFT_VAL = 4
 RUN_GAS_DISABLE = 0
 RUN_GAS_ENABLE = 1
 
+# Gas heater enable and disable settings
+GAS_HEAT_ENABLE = 0
+GAS_HEAT_DISABLE = 1
+
 # Buffer length macro declaration
 TMP_BUFFER_LENGTH = 40
 REG_BUFFER_LENGTH = 6


### PR DESCRIPTION
Since the logic is reversed and setting the heat_off bit to 1 disables the heater, these constants should avoid confusion.